### PR TITLE
Add the new field for upload image URL in pet forms

### DIFF
--- a/peluditos-ya-client/src/app/components/register-animal/register-animal.component.html
+++ b/peluditos-ya-client/src/app/components/register-animal/register-animal.component.html
@@ -18,7 +18,7 @@
     <input type="file" (change)="onMedicalFileSelected($event)" />
 
     <label>Foto:</label>
-    <input type="file" (change)="onPhotoSelected($event)" />
+    <input type="text" name="photoUrl" [(ngModel)]="nuevaMascota.photoUrl" placeholder="URL de la foto" required />
 
     <button type="submit">Registrar Mascota</button>
     </form>

--- a/peluditos-ya-client/src/app/components/register-animal/register-animal.component.ts
+++ b/peluditos-ya-client/src/app/components/register-animal/register-animal.component.ts
@@ -19,17 +19,13 @@ export class RegisterAnimalComponent {
     behavior: '',
     shelterId: '',
     medicalFile: null,
-    photo: null
+    photoUrl: ''  // Usamos solo la URL
   };
 
   constructor(private animalService: AnimalService) {}
 
   onMedicalFileSelected(event: any) {
     this.nuevaMascota.medicalFile = event.target.files[0];
-  }
-
-  onPhotoSelected(event: any) {
-    this.nuevaMascota.photo = event.target.files[0];
   }
 
   registrarMascota() {

--- a/peluditos-ya-client/src/app/pages/adoption/adoption.component.ts
+++ b/peluditos-ya-client/src/app/pages/adoption/adoption.component.ts
@@ -87,7 +87,7 @@ export class AdoptionComponent implements OnInit, AfterViewInit {
             edad: edadTexto, // Usamos 'cachorro' o 'adulto'
             sexo: mascota.sex,
             descripcion: `Tiene ${mascota.age} años de edad, ${this.traducirTipo(mascota.animalType).toLowerCase()} de raza ${mascota.breed}`,
-            imagen: 'https://img.freepik.com/foto-gratis/perro-pug-aislado-fondo-blanco_2829-11416.jpg?semt=ais_hybrid&w=740' // URL de imagen de ejemplo, considera usar imagen real de la mascota
+            imagen: mascota.photoUrl || 'https://files.lafm.com.co/assets/public/styles/twitter/public/2023-08/murio_cheems_el_perrito_de_los_meme.jpg.webp?VersionId=dHwATkyc2gQxvSwNeWXyOFUXPzaF3bbQ&itok=MmkIcD6M' // Imagen por defecto si no hay URL
           };
         });
       },

--- a/peluditos-ya-client/src/app/pages/pet-profile/pet-profile.component.css
+++ b/peluditos-ya-client/src/app/pages/pet-profile/pet-profile.component.css
@@ -1,5 +1,5 @@
 /* Responsive Pet Profile Styles */
-.pet-profile-container {
+.profile-container {
   max-width: 1200px;
   margin: 0 auto;
   padding: 1rem;

--- a/peluditos-ya-client/src/app/pages/pet-profile/pet-profile.component.html
+++ b/peluditos-ya-client/src/app/pages/pet-profile/pet-profile.component.html
@@ -1,16 +1,27 @@
 <div class="profile-container" *ngIf="!loading && pet; else loadingTemplate">
-  <div class="profile-card">
-    <img class="pet-photo" [src]="defaultImage" alt="Foto de {{ pet.name }}">
-    
-    <div class="profile-details">
-      <h2>{{ pet.name }}</h2>
-      <p><strong>Tipo:</strong> {{ pet.animalType }}</p>
-      <p><strong>Raza:</strong> {{ pet.breed }}</p>
-      <p><strong>Edad:</strong> {{ pet.age }}</p>
-      <p><strong>Comportamiento:</strong> {{ pet.behavior }}</p>
-      <a class="medical-link" [href]="pet.medicalFilePath" target="_blank">Ver archivo médico</a>
+  <div class="pet-profile">
+    <!-- Pet Header -->
+    <div class="pet-header">
+      <img [src]="pet.photoPath || defaultImage" alt="Foto de {{ pet.name }}">
+      <div>
+        <h1>{{ pet.name }}</h1>
+        <p><strong>Tipo:</strong> {{ pet.animalType }}</p>
+        <p><strong>Raza:</strong> {{ pet.breed }}</p>
+        <p><strong>Edad:</strong> {{ pet.age }}</p>
+        <p><strong>Comportamiento:</strong> {{ pet.behavior }}</p>
+      </div>
+    </div>
 
-      <div *ngIf="!pet.sponsor" class="qr-box">
+    <!-- Información de la mascota -->
+    <div class="pet-section">
+      <h2>Información médica</h2>
+      <a class="medical-link" [href]="pet.medicalFilePath" target="_blank">Ver archivo médico</a>
+    </div>
+
+    <!-- QR y apadrinamiento -->
+    <div class="pet-section" *ngIf="!pet.sponsor">
+      <h2>Apadrinamiento</h2>
+      <div class="qr-box">
         <h3>¡Apadrina a {{ pet.name }}!</h3>
         <div *ngIf="qrCodeImage" class="qr-image">
           <img [src]="qrCodeImage" alt="Código QR de apadrinamiento" />
@@ -20,19 +31,21 @@
         </button>
       </div>
     </div>
-  </div>
 
-  <div class="shelter-info" *ngIf="shelter">
-    <h3>Refugio</h3>
-    <p><strong>Nombre:</strong> {{ shelter.shelterName }}</p>
-    <p><strong>Dirección:</strong> {{ shelter.shelterAddress }}</p>
-    <p><strong>Teléfono:</strong> {{ shelter.phone }}</p>
-  </div>
+    <!-- Información del refugio -->
+    <div class="pet-section" *ngIf="shelter">
+      <h2>Refugio</h2>
+      <p><strong>Nombre:</strong> {{ shelter.shelterName }}</p>
+      <p><strong>Dirección:</strong> {{ shelter.shelterAddress }}</p>
+      <p><strong>Teléfono:</strong> {{ shelter.phone }}</p>
+    </div>
 
-  <div class="sponsor-info" *ngIf="pet?.sponsor">
-    <h3>Padrino</h3>
-    <p><strong>Nombre:</strong> {{ pet.sponsor.name }}</p>
-    <p><strong>Correo:</strong> {{ pet.sponsor.email }}</p>
+    <!-- Información del padrino -->
+    <div class="pet-section sponsor-info" *ngIf="pet?.sponsor">
+      <h2>Padrino</h2>
+      <p><strong>Nombre:</strong> {{ pet.sponsor.name }}</p>
+      <p><strong>Correo:</strong> {{ pet.sponsor.email }}</p>
+    </div>
   </div>
 </div>
 

--- a/peluditos-ya-client/src/app/services/auth.animal.service.ts
+++ b/peluditos-ya-client/src/app/services/auth.animal.service.ts
@@ -26,8 +26,12 @@ export class AnimalService {
       formData.append('medicalFile', formulario.medicalFile);
     }
 
-    if (formulario.photo) {
-      formData.append('photo', formulario.photo);
+    if (formulario.photoUrl) {
+    formData.append('photoUrl', formulario.photoUrl);
+    }
+
+    for (const pair of formData.entries()) {
+      console.log(`${pair[0]}: ${pair[1]}`);
     }
 
     return this.http.post(`${this.baseUrl}/register`, formData);

--- a/peluditos-ya-server/src/main/java/com/peluditosya/peluditos_ya_server/dto/AnimalDetailDTO.java
+++ b/peluditos-ya-server/src/main/java/com/peluditosya/peluditos_ya_server/dto/AnimalDetailDTO.java
@@ -18,6 +18,8 @@ public class AnimalDetailDTO {
     private String shelterPhone;
     private Long shelterId;
     private Long sponsorId;
+    private String photoUrl;
+
     
     // Getters and setters
     public Long getId() {
@@ -127,4 +129,12 @@ public class AnimalDetailDTO {
     public Long getShelterId(){return shelterId;}
 
     public void setShelterId(Long shelterid){ this.shelterId = shelterid; }
+
+    public String getPhotoUrl() {
+    return photoUrl;
+    }
+
+    public void setPhotoUrl(String photoUrl) {
+        this.photoUrl = photoUrl;
+    }
 }

--- a/peluditos-ya-server/src/main/java/com/peluditosya/peluditos_ya_server/dto/AnimalRegistrationRequest.java
+++ b/peluditos-ya-server/src/main/java/com/peluditosya/peluditos_ya_server/dto/AnimalRegistrationRequest.java
@@ -11,6 +11,8 @@ public class AnimalRegistrationRequest {
     private MultipartFile medicalFile;
     private MultipartFile photo;
     private Long shelterId;
+    private String photoUrl;
+
 
     // Getters and setters
     public String getName() {
@@ -75,5 +77,13 @@ public class AnimalRegistrationRequest {
 
     public void setShelterId(Long shelterId) {
         this.shelterId = shelterId;
+    }
+
+    public String getPhotoUrl() {
+    return photoUrl;
+    }
+
+    public void setPhotoUrl(String photoUrl) {
+        this.photoUrl = photoUrl;
     }
 }

--- a/peluditos-ya-server/src/main/java/com/peluditosya/peluditos_ya_server/service/AnimalService.java
+++ b/peluditos-ya-server/src/main/java/com/peluditosya/peluditos_ya_server/service/AnimalService.java
@@ -42,7 +42,12 @@ public class AnimalService {
         ShelterRequest shelterRequest = shelterRequestOpt.get();
 
         String medicalFilePath = fileStorageService.storeFile(request.getMedicalFile(), "medical-files");
-        String photoPath = fileStorageService.storeFile(request.getPhoto(), "animal-photos");
+        String photoPath = null;
+        if (request.getPhoto() != null && !request.getPhoto().isEmpty()) {
+            photoPath = fileStorageService.storeFile(request.getPhoto(), "animal-photos");
+        } else if (request.getPhotoUrl() != null && !request.getPhotoUrl().isEmpty()) {
+            photoPath = request.getPhotoUrl();
+        }
 
         Animal animal = new Animal();
         animal.setName(request.getName());


### PR DESCRIPTION
This PR updates the pet registration functionality by replacing image file uploads with the ability to provide an external image URL as the pet’s profile photo.
Removed the file upload logic for pet photos.

The photoPath field is now set directly from a user-provided URL (photoUrl).

Updated the frontend form to accept an image URL instead of a file upload.

Adapted backend DTO, controller, and service layers to handle and store the image URL correctly.

Maintained logic to display a default image if no URL is provided.

Ensured that only authorized users can perform these actions.

![image](https://github.com/user-attachments/assets/f4808052-ba74-49fb-857f-f14952bfe31c)
![image](https://github.com/user-attachments/assets/1836db48-8479-4e32-acaa-814d41ce486d)
